### PR TITLE
Standardise use of "Log in" copy

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -3,7 +3,7 @@
 Safeguarding is the actions taken to promote the welfare of children and protect them from harm.
 
 <p style="border-left: solid; border-width:10px; border-color: #0faeb0; background-color: aliceblue; padding: 10px;">
-<span style="color: #0faeb0">**To save**</span> your progress in this module, you will need to be logged in with your Raspberry Pi Foundation account. Use the ‘Sign in’ link in the navigation menu to log in.
+<span style="color: #0faeb0">**To save**</span> your progress in this module, you will need to be logged in with your Raspberry Pi Foundation account. Use the ‘Log in’ link in the navigation menu to log in.
 </p>
 
 ![Three young people standing.](images/3-RPF-Kids.png)


### PR DESCRIPTION
We generally try to use "Log in" rather than "Sign in".